### PR TITLE
use more conventional `.deinit()` syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ test "mytest" {
     // Initialize the xor filter with room for 10000 keys.
     const size = 10000; // room for 10000 keys
     const filter = try xorfilter.Xor8.init(allocator, size);
-    defer filter.deinit(allocator);
+    defer filter.deinit();
 
     // Generate some consecutive keys.
     var keys = try allocator.alloc(u64, size);
@@ -68,9 +68,8 @@ test "mytest" {
     // If your keys are not unique, make them so:
     keys = xorfilter.Unique(u64)(keys);
 
-    // If this fails, your keys are not unique.
-    var success = try filter.populate(allocator, keys[0..]);
-    testing.expect(success == true);
+    // If this fails, your keys are not unique or allocation failed.
+    try filter.populate(allocator, keys[0..]);
 
     // Now we can quickly test for containment!
     testing.expect(filter.contain(1) == true);

--- a/src/benchmark.zig
+++ b/src/benchmark.zig
@@ -31,7 +31,7 @@ fn xorBench(T: anytype, size: usize, trials: usize) !void {
     // Initialize filter.
     var start = timer.lap();
     const filter = try xorfilter.Xor(T).init(allocator, size);
-    defer filter.destroy(allocator);
+    defer filter.deinit();
     var end = timer.read();
     try stdout.print("init:\t", .{});
     try formatTime(stdout, start, end, 1);

--- a/src/main.zig
+++ b/src/main.zig
@@ -12,16 +12,16 @@ test "exports" {
     const allocator = std.heap.page_allocator;
 
     const fuse8Filter = try Fuse8.init(allocator, 1);
-    defer fuse8Filter.destroy(allocator);
+    defer fuse8Filter.deinit();
 
     const xorFilter = try Xor(u8).init(allocator, 1);
-    defer xorFilter.destroy(allocator);
+    defer xorFilter.deinit();
 
     const xor8Filter = try Xor8.init(allocator, 1);
-    defer xor8Filter.destroy(allocator);
+    defer xor8Filter.deinit();
 
     const xor16Filter = try Xor16.init(allocator, 1);
-    defer xor16Filter.destroy(allocator);
+    defer xor16Filter.deinit();
 
     var array = [_]i32{ 1, 2, 2 };
     const unique = AutoUnique(i32)(array[0..]);

--- a/src/util.zig
+++ b/src/util.zig
@@ -36,6 +36,7 @@ pub fn fingerprint(hash: u64) callconv(.Inline) u64 {
 
 pub fn sliceIterator(comptime T: type) type {
     return struct {
+        allocator: *Allocator,
         slice: []T,
         i: usize,
 
@@ -44,14 +45,15 @@ pub fn sliceIterator(comptime T: type) type {
         pub fn init(allocator: *Allocator, slice: []T) callconv(.Inline) !*Self {
             const self = try allocator.create(Self);
             self.* = Self{
+                .allocator = allocator,
                 .i = 0,
                 .slice = slice,
             };
             return self;
         }
 
-        pub fn destroy(self: *Self, allocator: *Allocator) callconv(.Inline) void {
-            allocator.destroy(self);
+        pub fn deinit(self: *Self) callconv(.Inline) void {
+            self.allocator.destroy(self);
         }
 
         pub fn next(self: *Self) callconv(.Inline) ?T {


### PR DESCRIPTION
`.destroy()` is used by `std.mem.Allocator` in Zig to describe destroying
_another object_, while `.deinit()` is the convention for destroying ones
own object (self) - so use that.

Additionally, store a pointer to the allocator we need to destroy ourselves
instead of requiring it be passed in. This is similar to how std.ArrayList
operates.

Signed-off-by: Stephen Gutekanst <stephen@hexops.com>