### PR TITLE
 Add much-improved benchmarking suite with more detailed numbers & better acccuracy

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,32 +125,47 @@ zig run -O ReleaseFast src/benchmark.zig -- --xor 8 --num-keys 1000000
 <details>
 <summary><strong>Benchmarks:</strong> 2019 Macbook Pro (1M - 100M keys)</summary>
 
-* CPU: 2.3Ghz Intel Core i9
+* CPU: 2.3 GHz 8-Core Intel Core i9
 * Memory: 16 GB 2667 MHz DDR4
-* Zig version: ``0.8.0-dev.1032+8098b3f84`
+* Zig version: `0.9.0-dev.369+254a35fd8`
 
-| Algorithm | # of keys | populate | time per containment check | fpp (estimated) | bits per entry (memory) |
-|-----------|-----------|----------|----------------------------|-----------------|-------------------------|
-| xor4      | 1M        | 92ms     | 28ns/check                 | 0.0625333000    | 9.8                     |
-| xor8      | 1M        | 124ms    | 29ns/check                 | 0.0039010000    | 9.8                     |
-| xor16     | 1M        | 106ms    | 30ns/check                 | 0.0000140000    | 19.7                    |
-| xor32     | 1M        | 99ms     | 33ns/check                 | 0.0000000000    | 39.4                    |
-| fuse8     | 1M        | 96ms     | 28ns/check                 | 0.0039010000    | 9.8                     |
-| fuse16    | 1M        | 93ms     | 30ns/check                 | 0.0000140000    | 19.7                    |
-|           |           |          |                            |                 |                         |
-| xor4      | 10M       | 1.6s     | 90ns/check                 | 0.0626137000    | 9.8                     |
-| xor8      | 10M       | 1.6s     | 89ns/check                 | 0.0039369000    | 9.8                     |
-| xor16     | 10M       | 1.6s     | 105ns/check                | 0.0000173000    | 19.7                    |
-| xor32     | 10M       | 1.6s     | 119ns/check                | 0.0000000000    | 39.4                    |
-| fuse8     | 10M       | 1.6s     | 92ns/check                 | 0.0039369000    | 9.8                     |
-| fuse16    | 10M       | 1.6s     | 113ns/check                | 0.0000173000    | 19.7                    |
-|           |           |          |                            |                 |                         |
-| xor4      | 100M      | 23s      | 128ns/check                | 0.0625772000    | 9.8                     |
-| xor8      | 100M      | 20s      | 125ns/check                | 0.0039238000    | 9.8                     |
-| xor16     | 100M      | 21s      | 136ns/check                | 0.0000147000    | 19.7                    |
-| xor32     | 100M      | 22s      | 135ns/check                | 0.0000000000    | 39.4                    |
-| fuse8     | 100M      | 21s      | 124ns/check                | 0.0039238000    | 9.8                     |
-| fuse16    | 100M      | 22s      | 126ns/check                | 0.0000147000    | 19.7                    |
+| Algorithm  | # of keys  | populate   | contains(k) | false+ prob. | bits per entry | peak populate | filter total |
+|------------|------------|------------|-------------|--------------|----------------|---------------|--------------|
+| xor2       | 1000000    |   106.4ms  |     25.0ns  |    0.2500479 |           9.84 |        52 MiB |        1 MiB |
+| xor4       | 1000000    |    97.7ms  |     25.0ns  |   0.06253865 |           9.84 |        52 MiB |        1 MiB |
+| xor8       | 1000000    |    99.8ms  |     26.0ns  |    0.0039055 |           9.84 |        52 MiB |        1 MiB |
+| xor16      | 1000000    |    98.2ms  |     25.0ns  |   0.00001509 |          19.68 |        52 MiB |        2 MiB |
+| xor32      | 1000000    |   105.2ms  |     26.0ns  |            0 |          39.36 |        52 MiB |        4 MiB |
+| fuse8      | 1000000    |    81.7ms  |     25.0ns  |   0.00390901 |           9.10 |        49 MiB |        1 MiB |
+| fuse16     | 1000000    |    85.5ms  |     26.0ns  |    0.0000147 |          18.20 |        49 MiB |        2 MiB |
+| fuse32     | 1000000    |    88.9ms  |     26.0ns  |            0 |          36.40 |        49 MiB |        4 MiB |
+|            |            |            |             |              |                |               |              |
+| xor2       | 10000000   |     1.7s   |     49.0ns  |    0.2500703 |           9.84 |       527 MiB |       11 MiB |
+| xor4       | 10000000   |     2.0s   |     45.0ns  |    0.0626137 |           9.84 |       527 MiB |       11 MiB |
+| xor8       | 10000000   |     2.0s   |     48.0ns  |    0.0039369 |           9.84 |       527 MiB |       11 MiB |
+| xor16      | 10000000   |     2.1s   |    109.0ns  |    0.0000173 |          19.68 |       527 MiB |       23 MiB |
+| xor32      | 10000000   |     2.2s   |    144.0ns  |            0 |          39.36 |       527 MiB |       46 MiB |
+| fuse8      | 10000000   |     1.5s   |     38.0ns  |    0.0039017 |           9.10 |       499 MiB |       10 MiB |
+| fuse16     | 10000000   |     1.5s   |    104.0ns  |    0.0000174 |          18.20 |       499 MiB |       21 MiB |
+| fuse32     | 10000000   |     1.5s   |    137.0ns  |            0 |          36.40 |       499 MiB |       43 MiB |
+|            |            |            |             |              |                |               |              |
+| xor2       | 100000000  |    27.6s   |    138.0ns  |     0.249843 |           9.84 |         5 GiB |      117 MiB |
+| xor4       | 100000000  |    27.9s   |    159.0ns  |     0.062338 |           9.84 |         5 GiB |      117 MiB |
+| xor8       | 100000000  |    27.8s   |    124.0ns  |     0.004016 |           9.84 |         5 GiB |      117 MiB |
+| xor16      | 100000000  |    29.5s   |    184.0ns  |     0.000012 |          19.68 |         5 GiB |      234 MiB |
+| xor32      | 100000000  |    31.5s   |    212.0ns  |            0 |          39.36 |         5 GiB |      469 MiB |
+| fuse8      | 100000000  |    23.4s   |    130.0ns  |     0.003887 |           9.10 |         4 GiB |      108 MiB |
+| fuse16     | 100000000  |    24.5s   |    133.0ns  |     0.000014 |          18.20 |         4 GiB |      216 MiB |
+| fuse32     | 100000000  |    25.5s   |    165.0ns  |            0 |          36.40 |         4 GiB |      433 MiB |
+|            |            |            |             |              |                |               |              |
+
+Legend:
+
+* contains(k): The time taken to check if a key is in the filter
+* false+ prob.: False positive probability, the probability that a containment check will erroneously return true for a key that has not actually been added to the filter.
+* bits per entry: The amount of memory in bits the filter uses to store a single entry.
+* peak populate: Amount of memory consumed during filter population, excluding keys themselves (8 bytes * num_keys.)
+* filter total: Amount of memory consumed for filter itself in total (bits per entry * entries.)
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -4,13 +4,16 @@
 
 This is a [Zig](https://ziglang.org) implementation of Xor Filters and Fuse Filters, which are faster and smaller than Bloom and Cuckoo filters and allow for quickly checking if a key is part of a set.
 
-- [Benefits of Zig implementation](#benefits-of-zig-implementation)
-- [Research papers](#research-papers)
-- [Usage](#usage)
-- [Serialization](#serialization)
-- [Note about extremely large datasets](#note-about-extremely-large-datasets)
-- [Special thanks](#special-thanks)
-- [Changelog](#changelog)
+- [xorfilter: Zig implementation of Xor Filters <a href="https://hexops.com"><img align="right" alt="Hexops logo" src="https://raw.githubusercontent.com/hexops/media/main/readme.svg"></img></a>](#xorfilter-zig-implementation-of-xor-filters-img)
+  - [Benefits of Zig implementation](#benefits-of-zig-implementation)
+  - [Research papers](#research-papers)
+  - [Usage](#usage)
+  - [Serialization](#serialization)
+  - [Should I use xor filters or fuse filters?](#should-i-use-xor-filters-or-fuse-filters)
+  - [Note about extremely large datasets](#note-about-extremely-large-datasets)
+  - [Benchmarks](#benchmarks)
+  - [Special thanks](#special-thanks)
+  - [Changelog](#changelog)
 
 ## Benefits of Zig implementation
 
@@ -203,4 +206,6 @@ If it was not for the above people, I ([@slimsag](https://github.com/slimsag)) w
 
 The API is generally finalized, but we may make some adjustments as Zig changes or we learn of more idiomatic ways to express things. We will release v1.0 once Zig v1.0 is released.
 
+- **v0.9.0** (not yet published):
+  - Added much improved benchmarking suite with more details on memory consumption during filter population, etc.
 - **v0.8.0**: initial release with support for Xor and Fuse filters of varying bit sizes, key iterators, serialization, and a slice de-duplication helper.

--- a/README.md
+++ b/README.md
@@ -161,11 +161,11 @@ zig run -O ReleaseFast src/benchmark.zig -- --xor 8 --num-keys 1000000
 
 Legend:
 
-* contains(k): The time taken to check if a key is in the filter
-* false+ prob.: False positive probability, the probability that a containment check will erroneously return true for a key that has not actually been added to the filter.
-* bits per entry: The amount of memory in bits the filter uses to store a single entry.
-* peak populate: Amount of memory consumed during filter population, excluding keys themselves (8 bytes * num_keys.)
-* filter total: Amount of memory consumed for filter itself in total (bits per entry * entries.)
+* **contains(k)**: The time taken to check if a key is in the filter
+* **false+ prob.**: False positive probability, the probability that a containment check will erroneously return true for a key that has not actually been added to the filter.
+* **bits per entry**: The amount of memory in bits the filter uses to store a single entry.
+* **peak populate**: Amount of memory consumed during filter population, excluding keys themselves (8 bytes * num_keys.)
+* **filter total**: Amount of memory consumed for filter itself in total (bits per entry * entries.)
 
 </details>
 
@@ -208,11 +208,11 @@ Legend:
 
 Legend:
 
-* contains(k): The time taken to check if a key is in the filter
-* false+ prob.: False positive probability, the probability that a containment check will erroneously return true for a key that has not actually been added to the filter.
-* bits per entry: The amount of memory in bits the filter uses to store a single entry.
-* peak populate: Amount of memory consumed during filter population, excluding keys themselves (8 bytes * num_keys.)
-* filter total: Amount of memory consumed for filter itself in total (bits per entry * entries.)
+* **contains(k)**: The time taken to check if a key is in the filter
+* **false+ prob.**: False positive probability, the probability that a containment check will erroneously return true for a key that has not actually been added to the filter.
+* **bits per entry**: The amount of memory in bits the filter uses to store a single entry.
+* **peak populate**: Amount of memory consumed during filter population, excluding keys themselves (8 bytes * num_keys.)
+* **filter total**: Amount of memory consumed for filter itself in total (bits per entry * entries.)
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ zig run -O ReleaseFast src/benchmark.zig -- --xor 8 --num-keys 1000000
 ```
 
 <details>
-<summary><strong>Benchmarks:</strong> 2019 Macbook Pro (1M - 100M keys)</summary>
+<summary><strong>Benchmarks:</strong> 2019 Macbook Pro, Intel i9 (1M - 100M keys)</summary>
 
 * CPU: 2.3 GHz 8-Core Intel Core i9
 * Memory: 16 GB 2667 MHz DDR4
@@ -170,41 +170,49 @@ Legend:
 </details>
 
 <details>
-<summary><strong>Benchmarks:</strong> Windows 10 WSL2 Desktop (1M - 250M keys)</summary>
+<summary><strong>Benchmarks:</strong> Windows 10, AMD Ryzen 9 3900X (1M - 100M keys)</summary>
 
 * CPU: 3.79Ghz AMD Ryzen 9 3900X
 * Memory: 32 GB 2133 MHz DDR4
-* Zig version: ``0.8.0-dev.1039+bea791b63`
+* Zig version: `0.9.0-dev.450+aa2a31612`
 
-| Algorithm | # of keys | populate | time per containment check | fpp (estimated) | bits per entry (memory) |
-|-----------|-----------|----------|----------------------------|-----------------|-------------------------|
-| xor4      | 1M        | 112ms    | 23ns/check                 | 0.0625333000    | 9.8                     |
-| xor8      | 1M        | 112ms    | 23ns/check                 | 0.0039010000    | 9.8                     |
-| xor16     | 1M        | 117ms    | 24ns/check                 | 0.0000140000    | 19.7                    |
-| xor32     | 1M        | 119ms    | 25ns/check                 | 0.0000000000    | 39.4                    |
-| fuse8     | 1M        | 112ms    | 23ns/check                 | 0.0039010000    | 9.8                     |
-| fuse16    | 1M        | 115ms    | 24ns/check                 | 0.0000140000    | 19.7                    |
-|           |           |          |                            |                 |                         |
-| xor4      | 10M       | 1.6s     | 39ns/check                 | 0.0626137000    | 9.8                     |
-| xor8      | 10M       | 1.6s     | 38ns/check                 | 0.0039369000    | 9.8                     |
-| xor16     | 10M       | 1.7s     | 126ns/check                | 0.0000173000    | 19.7                    |
-| xor32     | 10M       | 1.8s     | 158ns/check                | 0.0000000000    | 39.4                    |
-| fuse8     | 10M       | 1.6s     | 38ns/check                 | 0.0039369000    | 9.8                     |
-| fuse16    | 10M       | 1.7s     | 127ns/check                | 0.0000173000    | 19.7                    |
-|           |           |          |                            |                 |                         |
-| xor4      | 100M      | 21s      | 175ns/check                | 0.0625772000    | 9.8                     |
-| xor8      | 100M      | 20s      | 175ns/check                | 0.0039238000    | 9.8                     |
-| xor16     | 100M      | 20s      | 180ns/check                | 0.0000147000    | 19.7                    |
-| xor32     | 100M      | 20s      | 190ns/check                | 0.0000000000    | 39.4                    |
-| fuse8     | 100M      | 20s      | 181ns/check                | 0.0039238000    | 9.8                     |
-| fuse16    | 100M      | 20s      | 183ns/check                | 0.0000147000    | 19.7                    |
-|           |           |          |                            |                 |                         |
-| xor4      | 250M      | 1.1min   | 194ns/check                | 0.0625503000    | 9.8                     |
-| xor8      | 250M      | 1.2min   | 190ns/check                | 0.0038876000    | 9.8                     |
-| xor16     | 250M      | 1.2min   | 196ns/check                | 0.0000125000    | 19.7                    |
-| xor32     | 250M      | 1.1min   | 203ns/check                | 0.0000000000    | 39.4                    |
-| fuse8     | 250M      | 1.1min   | 199ns/check                | 0.0038876000    | 9.8                     |
-| fuse16    | 250M      | 1.1min   | 203ns/check                | 0.0000125000    | 19.7                    |
+| Algorithm  | # of keys  | populate   | contains(k) | false+ prob. | bits per entry | peak populate | filter total |
+|------------|------------|------------|-------------|--------------|----------------|---------------|--------------|
+| xor2       | 1000000    |    74.5ms  |     25.0ns  |   0.25000163 |           9.84 |        52 MiB |        1 MiB |
+| xor4       | 1000000    |    84.4ms  |     25.0ns  |   0.06250427 |           9.84 |        52 MiB |        1 MiB |
+| xor8       | 1000000    |    73.8ms  |     25.0ns  |   0.00391662 |           9.84 |        52 MiB |        1 MiB |
+| xor16      | 1000000    |    75.9ms  |     25.0ns  |   0.00001536 |          19.68 |        52 MiB |        2 MiB |
+| xor32      | 1000000    |    76.1ms  |     25.0ns  |            0 |          39.36 |        52 MiB |        4 MiB |
+| fuse8      | 1000000    |    65.3ms  |     24.0ns  |   0.00390663 |           9.10 |        49 MiB |        1 MiB |
+| fuse16     | 1000000    |    68.3ms  |     25.0ns  |   0.00001516 |          18.20 |        49 MiB |        2 MiB |
+| fuse32     | 1000000    |    70.2ms  |     26.0ns  |            0 |          36.40 |        49 MiB |        4 MiB |
+|            |            |            |             |              |                |               |              |
+| xor2       | 10000000   |     1.1s   |     35.0ns  |     0.249876 |           9.84 |       527 MiB |       11 MiB |
+| xor4       | 10000000   |     1.1s   |     37.0ns  |    0.0625026 |           9.84 |       527 MiB |       11 MiB |
+| xor8       | 10000000   |     1.1s   |     35.0ns  |    0.0038881 |           9.84 |       527 MiB |       11 MiB |
+| xor16      | 10000000   |     1.3s   |    114.0ns  |    0.0000134 |          19.68 |       527 MiB |       23 MiB |
+| xor32      | 10000000   |     1.3s   |    144.0ns  |            0 |          39.36 |       527 MiB |       46 MiB |
+| fuse8      | 10000000   |     1.0s   |     34.0ns  |    0.0039089 |           9.10 |       499 MiB |       10 MiB |
+| fuse16     | 10000000   |     1.0s   |    106.0ns  |    0.0000172 |          18.20 |       499 MiB |       21 MiB |
+| fuse32     | 10000000   |     1.1s   |    142.0ns  |            0 |          36.40 |       499 MiB |       43 MiB |
+|            |            |            |             |              |                |               |              |
+| xor2       | 100000000  |    20.2s   |    166.0ns  |     0.249868 |           9.84 |         5 GiB |      117 MiB |
+| xor4       | 100000000  |    20.2s   |    167.0ns  |     0.062417 |           9.84 |         5 GiB |      117 MiB |
+| xor8       | 100000000  |    19.2s   |    166.0ns  |     0.003873 |           9.84 |         5 GiB |      117 MiB |
+| xor16      | 100000000  |    17.9s   |    169.0ns  |     0.000021 |          19.68 |         5 GiB |      234 MiB |
+| xor32      | 100000000  |    20.3s   |    181.0ns  |            0 |          39.36 |         5 GiB |      469 MiB |
+| fuse8      | 100000000  |    20.6s   |    166.0ns  |     0.003797 |           9.10 |         4 GiB |      108 MiB |
+| fuse16     | 100000000  |    21.6s   |    170.0ns  |     0.000015 |          18.20 |         4 GiB |      216 MiB |
+| fuse32     | 100000000  |    21.4s   |    174.0ns  |            0 |          36.40 |         4 GiB |      433 MiB |
+|            |            |            |             |              |                |               |              |
+
+Legend:
+
+* contains(k): The time taken to check if a key is in the filter
+* false+ prob.: False positive probability, the probability that a containment check will erroneously return true for a key that has not actually been added to the filter.
+* bits per entry: The amount of memory in bits the filter uses to store a single entry.
+* peak populate: Amount of memory consumed during filter population, excluding keys themselves (8 bytes * num_keys.)
+* filter total: Amount of memory consumed for filter itself in total (bits per entry * entries.)
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -208,4 +208,5 @@ The API is generally finalized, but we may make some adjustments as Zig changes 
 
 - **v0.9.0** (not yet published):
   - Added much improved benchmarking suite with more details on memory consumption during filter population, etc.
+  - Properly exposed the `Fuse(T)` type, for arbitrary-bit-size fuse filters.
 - **v0.8.0**: initial release with support for Xor and Fuse filters of varying bit sizes, key iterators, serialization, and a slice de-duplication helper.

--- a/src/MeasuredAllocator.zig
+++ b/src/MeasuredAllocator.zig
@@ -1,0 +1,53 @@
+/// This allocator takes an existing allocator, wraps it, and provides measurements about the
+/// allocations such as peak memory usage.
+const std = @import("std");
+const assert = std.debug.assert;
+const mem = std.mem;
+const Allocator = std.mem.Allocator;
+
+const MeasuredAllocator = @This();
+
+allocator: Allocator,
+
+child_allocator: *Allocator,
+state: State,
+
+/// Inner state of MeasuredAllocator. Can be stored rather than the entire MeasuredAllocator as a
+/// memory-saving optimization.
+pub const State = struct {
+    peak_memory_usage_bytes: usize = 0,
+    current_memory_usage_bytes: usize = 0,
+
+    pub fn promote(self: State, child_allocator: *Allocator) MeasuredAllocator {
+        return .{
+            .allocator = Allocator{
+                .allocFn = alloc,
+                .resizeFn = resize,
+            },
+            .child_allocator = child_allocator,
+            .state = self,
+        };
+    }
+};
+
+const BufNode = std.SinglyLinkedList([]u8).Node;
+
+pub fn init(child_allocator: *Allocator) MeasuredAllocator {
+    return (State{}).promote(child_allocator);
+}
+
+fn alloc(allocator: *Allocator, n: usize, ptr_align: u29, len_align: u29, ra: usize) ![]u8 {
+    const self = @fieldParentPtr(MeasuredAllocator, "allocator", allocator);
+    const m = try self.child_allocator.allocFn(self.child_allocator, n, ptr_align, len_align, ra);
+    self.state.current_memory_usage_bytes += n;
+    if (self.state.current_memory_usage_bytes > self.state.peak_memory_usage_bytes) self.state.peak_memory_usage_bytes = self.state.current_memory_usage_bytes;
+    return m;
+}
+
+fn resize(allocator: *Allocator, buf: []u8, buf_align: u29, new_len: usize, len_align: u29, ret_addr: usize) Allocator.Error!usize {
+    const self = @fieldParentPtr(MeasuredAllocator, "allocator", allocator);
+    const final_len = try self.child_allocator.resizeFn(self.child_allocator, buf, buf_align, new_len, len_align, ret_addr);
+    self.state.current_memory_usage_bytes -= buf.len - new_len;
+    if (self.state.current_memory_usage_bytes > self.state.peak_memory_usage_bytes) self.state.peak_memory_usage_bytes = self.state.current_memory_usage_bytes;
+    return final_len;
+}

--- a/src/benchmark.zig
+++ b/src/benchmark.zig
@@ -170,9 +170,9 @@ pub fn main() !void {
     try stdout.print("|            |            |            |             |              |                |               |              |\n", .{});
     try stdout.print("\n", .{});
     try stdout.print("Legend:\n\n", .{});
-    try stdout.print("* contains(k): The time taken to check if a key is in the filter\n", .{});
-    try stdout.print("* false+ prob.: False positive probability, the probability that a containment check will erroneously return true for a key that has not actually been added to the filter.\n", .{});
-    try stdout.print("* bits per entry: The amount of memory in bits the filter uses to store a single entry.\n", .{});
-    try stdout.print("* peak populate: Amount of memory consumed during filter population, excluding keys themselves (8 bytes * num_keys.)\n", .{});
-    try stdout.print("* filter total: Amount of memory consumed for filter itself in total (bits per entry * entries.)\n", .{});
+    try stdout.print("* **contains(k)**: The time taken to check if a key is in the filter\n", .{});
+    try stdout.print("* **false+ prob.**: False positive probability, the probability that a containment check will erroneously return true for a key that has not actually been added to the filter.\n", .{});
+    try stdout.print("* **bits per entry**: The amount of memory in bits the filter uses to store a single entry.\n", .{});
+    try stdout.print("* **peak populate**: Amount of memory consumed during filter population, excluding keys themselves (8 bytes * num_keys.)\n", .{});
+    try stdout.print("* **filter total**: Amount of memory consumed for filter itself in total (bits per entry * entries.)\n", .{});
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 
+pub const Fuse = @import("fusefilter.zig").Fuse;
 pub const Fuse8 = @import("fusefilter.zig").Fuse8;
 pub const Xor = @import("xorfilter.zig").Xor;
 pub const Xor8 = @import("xorfilter.zig").Xor8;


### PR DESCRIPTION
This is a complete redesign of the benchmarking suite, with much more detailed numbers & better accuracy:

On a 2019 Macbook Pro (2.3 GHz 8-Core Intel Core i9, 16 GB 2667 MHz DDR4) this produces:

```
$ zig run -O ReleaseFast src/benchmark.zig
```

| Algorithm  | # of keys  | populate   | contains(k) | false+ prob. | bits per entry | peak populate | filter total |
|------------|------------|------------|-------------|--------------|----------------|---------------|--------------|
| xor2       | 1000000    |   106.4ms  |     25.0ns  |    0.2500479 |           9.84 |        52 MiB |        1 MiB |
| xor4       | 1000000    |    97.7ms  |     25.0ns  |   0.06253865 |           9.84 |        52 MiB |        1 MiB |
| xor8       | 1000000    |    99.8ms  |     26.0ns  |    0.0039055 |           9.84 |        52 MiB |        1 MiB |
| xor16      | 1000000    |    98.2ms  |     25.0ns  |   0.00001509 |          19.68 |        52 MiB |        2 MiB |
| xor32      | 1000000    |   105.2ms  |     26.0ns  |            0 |          39.36 |        52 MiB |        4 MiB |
| fuse8      | 1000000    |    81.7ms  |     25.0ns  |   0.00390901 |           9.10 |        49 MiB |        1 MiB |
| fuse16     | 1000000    |    85.5ms  |     26.0ns  |    0.0000147 |          18.20 |        49 MiB |        2 MiB |
| fuse32     | 1000000    |    88.9ms  |     26.0ns  |            0 |          36.40 |        49 MiB |        4 MiB |
|            |            |            |             |              |                |               |              |
| xor2       | 10000000   |     1.7s   |     49.0ns  |    0.2500703 |           9.84 |       527 MiB |       11 MiB |
| xor4       | 10000000   |     2.0s   |     45.0ns  |    0.0626137 |           9.84 |       527 MiB |       11 MiB |
| xor8       | 10000000   |     2.0s   |     48.0ns  |    0.0039369 |           9.84 |       527 MiB |       11 MiB |
| xor16      | 10000000   |     2.1s   |    109.0ns  |    0.0000173 |          19.68 |       527 MiB |       23 MiB |
| xor32      | 10000000   |     2.2s   |    144.0ns  |            0 |          39.36 |       527 MiB |       46 MiB |
| fuse8      | 10000000   |     1.5s   |     38.0ns  |    0.0039017 |           9.10 |       499 MiB |       10 MiB |
| fuse16     | 10000000   |     1.5s   |    104.0ns  |    0.0000174 |          18.20 |       499 MiB |       21 MiB |
| fuse32     | 10000000   |     1.5s   |    137.0ns  |            0 |          36.40 |       499 MiB |       43 MiB |
|            |            |            |             |              |                |               |              |
| xor2       | 100000000  |    27.6s   |    138.0ns  |     0.249843 |           9.84 |         5 GiB |      117 MiB |
| xor4       | 100000000  |    27.9s   |    159.0ns  |     0.062338 |           9.84 |         5 GiB |      117 MiB |
| xor8       | 100000000  |    27.8s   |    124.0ns  |     0.004016 |           9.84 |         5 GiB |      117 MiB |
| xor16      | 100000000  |    29.5s   |    184.0ns  |     0.000012 |          19.68 |         5 GiB |      234 MiB |
| xor32      | 100000000  |    31.5s   |    212.0ns  |            0 |          39.36 |         5 GiB |      469 MiB |
| fuse8      | 100000000  |    23.4s   |    130.0ns  |     0.003887 |           9.10 |         4 GiB |      108 MiB |
| fuse16     | 100000000  |    24.5s   |    133.0ns  |     0.000014 |          18.20 |         4 GiB |      216 MiB |
| fuse32     | 100000000  |    25.5s   |    165.0ns  |            0 |          36.40 |         4 GiB |      433 MiB |
|            |            |            |             |              |                |               |              |

Legend:

* **contains(k)**: The time taken to check if a key is in the filter
* **false+ prob.**: False positive probability, the probability that a containment check will erroneously return true for a key that has not actually been added to the filter.
* **bits per entry**: The amount of memory in bits the filter uses to store a single entry.
* **peak populate**: Amount of memory consumed during filter population, excluding keys themselves (8 bytes * num_keys.)
* **filter total**: Amount of memory consumed for filter itself in total (bits per entry * entries.)

Signed-off-by: Stephen Gutekanst <stephen@hexops.com>

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.